### PR TITLE
remove references to deprecated macro ao2_container_alloc_options

### DIFF
--- a/sccp_config.c
+++ b/sccp_config.c
@@ -455,17 +455,17 @@ static void *sccp_cfg_alloc(void)
 		goto error;
 	}
 
-	devices_cfg = ao2_container_alloc_options(AO2_ALLOC_OPT_LOCK_NOLOCK, SCCP_BUCKETS, sccp_device_cfg_hash, sccp_device_cfg_cmp);
+	devices_cfg = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_NOLOCK, 0, SCCP_BUCKETS, sccp_device_cfg_hash, NULL, sccp_device_cfg_cmp);
 	if (!devices_cfg) {
 		goto error;
 	}
 
-	lines_cfg = ao2_container_alloc_options(AO2_ALLOC_OPT_LOCK_NOLOCK, SCCP_BUCKETS, sccp_line_cfg_hash, sccp_line_cfg_cmp);
+	lines_cfg = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_NOLOCK, 0, SCCP_BUCKETS, sccp_line_cfg_hash, NULL, sccp_line_cfg_cmp);
 	if (!lines_cfg) {
 		goto error;
 	}
 
-	speeddials_cfg = ao2_container_alloc_options(AO2_ALLOC_OPT_LOCK_NOLOCK, SCCP_BUCKETS, sccp_speeddial_cfg_hash, sccp_speeddial_cfg_cmp);
+	speeddials_cfg = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_NOLOCK, 0, SCCP_BUCKETS, sccp_speeddial_cfg_hash, NULL, sccp_speeddial_cfg_cmp);
 	if (!speeddials_cfg) {
 		goto error;
 	}

--- a/sccp_device_registry.c
+++ b/sccp_device_registry.c
@@ -84,13 +84,13 @@ struct sccp_device_registry *sccp_device_registry_create(struct sccp_cfg *cfg)
 		return NULL;
 	}
 
-	registry->devices = ao2_container_alloc_options(AO2_ALLOC_OPT_LOCK_NOLOCK, SCCP_BUCKETS, sccp_device_hash, sccp_device_cmp);
+	registry->devices = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_NOLOCK, 0, SCCP_BUCKETS, sccp_device_hash, NULL, sccp_device_cmp);
 	if (!registry->devices) {
 		ast_free(registry);
 		return NULL;
 	}
 
-	registry->lines = ao2_container_alloc_options(AO2_ALLOC_OPT_LOCK_NOLOCK, SCCP_BUCKETS, sccp_line_hash, sccp_line_cmp);
+	registry->lines = ao2_container_alloc_hash(AO2_ALLOC_OPT_LOCK_NOLOCK, 0, SCCP_BUCKETS, sccp_line_hash, NULL, sccp_line_cmp);
 	if (!registry->lines) {
 		ao2_ref(registry->devices, -1);
 		ast_free(registry);


### PR DESCRIPTION
Why:

* Those macros are removed in Asterisk 17.3.0.