### PR TITLE
Wazo 2818 convert scripts python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ McNamara & Florian Overkamp.
 
 * http://documentation.wazo.community/en/stable/contributors/sccp.html
 * https://github.com/wazo-platform/wazo-libsccp
+
+## buildh
+[buildh](./buildh) is a python script used to compile and install the sccp channel driver on a remote wazo stack. 
+You need a configuration file with the following content, by default located at `~/.wazo-libsccp-buildh-config`:
+```
+[default]
+host = pcm-dev-primary
+directory = wazo-libsccp
+```
+Replace pcm-dev-primary by the hostname of your stack.
+
+Then on your Wazo stack install `asterisk-dev`:
+`apt update && apt install asterisk-dev`
+
+Finally you should be able to launch `./buildh make` to compile the sccp channel driver on your stack and `./buildh makei` to build and install it.

--- a/buildh
+++ b/buildh
@@ -6,7 +6,7 @@ import errno
 import os
 import subprocess
 import sys
-import collections
+from collections import UserDict, OrderedDict
 import itertools
 from typing import TextIO
 
@@ -14,12 +14,13 @@ CONFIG_FILE = '~/.wazo-libsccp-buildh-config'
 SHELL = 'sh'
 DEFAULT_RSYNC_SSH_CMD = "ssh"
 
-class CustomConfigParserStorage(collections.UserDict):
+
+class CustomConfigParserStorage(UserDict):
     """configparser storage class customized for asterisk format parsing"""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.data = collections.OrderedDict(self.data)
+        self.data = OrderedDict(self.data)
         self.counter = itertools.count(start=1)
 
     def __setitem__(self, k, v):
@@ -42,20 +43,6 @@ class AsteriskConfigParser(configparser.RawConfigParser):
             (option.split(":", maxsplit=1)[-1], value)
             for option, value in super().items(*args, **kwargs)
         ]
-
-
-def asterisk_parser(food: TextIO | None=None) -> AsteriskConfigParser:
-    parser = AsteriskConfigParser(
-        dict_type=CustomConfigParserStorage,
-        strict=False,
-        interpolation=None,
-        empty_lines_in_values=False,
-        inline_comment_prefixes=[";"]
-    )
-    if food:
-        parser.read_file(food)
-    return parser
-
 
 
 def main():
@@ -85,27 +72,41 @@ def main():
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--profile', default='default',
-                        help='profile to use')
-    parser.add_argument('-c', '--config-file', default=os.path.expanduser(CONFIG_FILE),
-                        type=argparse.FileType(mode="r"),
-                        help='config file to use')
-    parser.add_argument('-r', '--rsync-ssh', default=DEFAULT_RSYNC_SSH_CMD,
-                        type=str,
-                        help='ssh command to use for rsyncing the build files')
-    parser.add_argument('command', choices=['make', 'makei'],
-                        help='command to execute')
+    parser.add_argument('-p', '--profile', default='default', help='profile to use')
+    parser.add_argument(
+        '-c',
+        '--config-file',
+        default=os.path.expanduser(CONFIG_FILE),
+        type=argparse.FileType(mode="r"),
+        help='config file to use',
+    )
+    parser.add_argument(
+        '-r',
+        '--rsync-ssh',
+        default=DEFAULT_RSYNC_SSH_CMD,
+        type=str,
+        help='ssh command to use for rsyncing the build files',
+    )
+    parser.add_argument('command', choices=['make', 'makei'], help='command to execute')
     return parser.parse_args()
 
 
+def read_config(config_file: TextIO) -> AsteriskConfigParser:
+    parser = AsteriskConfigParser(
+        dict_type=CustomConfigParserStorage,
+        strict=False,
+        interpolation=None,
+        empty_lines_in_values=False,
+        inline_comment_prefixes=[";"],
+    )
+    parser.read_file(config_file)
+    return parser
 
-def read_config(config_file: TextIO):
-    config = asterisk_parser(config_file)
-    return config
 
-
-def command_make(profile: dict[str,str], rsync_ssh_cmd: str=DEFAULT_RSYNC_SSH_CMD):
-    local_script = _build_rsync_script(profile['host'], profile['directory'], ssh_cmd=rsync_ssh_cmd)
+def command_make(profile: dict[str, str], rsync_ssh_cmd: str = DEFAULT_RSYNC_SSH_CMD):
+    local_script = _build_rsync_script(
+        profile['host'], profile['directory'], ssh_cmd=rsync_ssh_cmd
+    )
     _exec_local_script(local_script)
 
     remote_script = []
@@ -114,8 +115,10 @@ def command_make(profile: dict[str,str], rsync_ssh_cmd: str=DEFAULT_RSYNC_SSH_CM
     _exec_remote_script('\n'.join(remote_script), profile['host'])
 
 
-def command_makei(profile: dict[str, str], rsync_ssh_cmd: str=DEFAULT_RSYNC_SSH_CMD):
-    local_script = _build_rsync_script(profile['host'], profile['directory'], ssh_cmd=rsync_ssh_cmd)
+def command_makei(profile: dict[str, str], rsync_ssh_cmd: str = DEFAULT_RSYNC_SSH_CMD):
+    local_script = _build_rsync_script(
+        profile['host'], profile['directory'], ssh_cmd=rsync_ssh_cmd
+    )
     _exec_local_script(local_script)
 
     remote_script = []
@@ -136,7 +139,9 @@ def _build_make_script() -> str:
     return f'make VERSION={version}'
 
 
-def _build_rsync_script(host: str, directory: str, ssh_cmd: str=DEFAULT_RSYNC_SSH_CMD) -> str:
+def _build_rsync_script(
+    host: str, directory: str, ssh_cmd: str = DEFAULT_RSYNC_SSH_CMD
+) -> str:
     return f'''
     rsync -v -e="{ssh_cmd}" -rlp \
     --include '*.c' \
@@ -159,7 +164,10 @@ def _exec_remote_script(script: str, host: str):
 def _exec_command(args: list[str], process_input: str):
     p = subprocess.run(args, input=process_input, stdout=subprocess.PIPE, text=True)
     if p.returncode:
-        print(f'command {args} returned non-zero status code: {p.returncode}', file=sys.stderr)
+        print(
+            f'command {args} returned non-zero status code: {p.returncode}',
+            file=sys.stderr,
+        )
 
 
 if __name__ == '__main__':

--- a/buildh
+++ b/buildh
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import collections
 import itertools
+from typing import TextIO
 
 CONFIG_FILE = '~/.wazo-libsccp-buildh-config'
 SHELL = 'sh'
@@ -43,7 +44,7 @@ class AsteriskConfigParser(configparser.RawConfigParser):
         ]
 
 
-def asterisk_parser(food=None) -> AsteriskConfigParser:
+def asterisk_parser(food: TextIO | None=None) -> AsteriskConfigParser:
     parser = AsteriskConfigParser(
         dict_type=CustomConfigParserStorage,
         strict=False,
@@ -82,7 +83,7 @@ def main():
     command_fun(profile)
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--profile', default='default',
                         help='profile to use')
@@ -100,7 +101,7 @@ def read_config(config_file: TextIO):
     return config
 
 
-def command_make(profile):
+def command_make(profile: dict):
     local_script = _build_rsync_script(profile['host'], profile['directory'])
     _exec_local_script(local_script)
 
@@ -110,7 +111,7 @@ def command_make(profile):
     _exec_remote_script('\n'.join(remote_script), profile['host'])
 
 
-def command_makei(profile):
+def command_makei(profile: dict):
     local_script = _build_rsync_script(profile['host'], profile['directory'])
     _exec_local_script(local_script)
 
@@ -123,16 +124,16 @@ def command_makei(profile):
     _exec_remote_script('\n'.join(remote_script), profile['host'])
 
 
-def _build_cd_script(directory):
+def _build_cd_script(directory: str) -> str:
     return f"cd '{directory}'"
 
 
-def _build_make_script():
-    version = subprocess.check_output(['git', 'describe']).rstrip()
+def _build_make_script() -> str:
+    version: str = subprocess.check_output(['git', 'describe'], text=True).rstrip()
     return f'make VERSION={version}'
 
 
-def _build_rsync_script(host, directory):
+def _build_rsync_script(host: str, directory: str) -> str:
     return f'''
     rsync -v -rlp \
     --include '*.c' \
@@ -144,15 +145,15 @@ def _build_rsync_script(host, directory):
     '''
 
 
-def _exec_local_script(script):
+def _exec_local_script(script: str):
     _exec_command([SHELL, '-e'], script)
 
 
-def _exec_remote_script(script, host):
+def _exec_remote_script(script: str, host: str):
     _exec_command(['ssh', '-l', 'root', host, SHELL, '-e'], script)
 
 
-def _exec_command(args, process_input):
+def _exec_command(args: list[str], process_input: str):
     p = subprocess.run(args, input=process_input, stdout=subprocess.PIPE, text=True)
     if p.returncode:
         print(f'command {args} returned non-zero status code: {p.returncode}', file=sys.stderr)

--- a/buildh
+++ b/buildh
@@ -1,26 +1,73 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
+from __future__ import annotations
 import argparse
 import configparser
 import errno
 import os
 import subprocess
 import sys
+import collections
+import itertools
 
 CONFIG_FILE = '~/.wazo-libsccp-buildh-config'
 SHELL = 'sh'
 
 
+class CustomConfigParserStorage(collections.UserDict):
+    """configparser storage class customized for asterisk format parsing"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data = collections.OrderedDict(self.data)
+        self.counter = itertools.count(start=1)
+
+    def __setitem__(self, k, v):
+        if isinstance(v, list):
+            # if list, we assume this is a new option declaration
+            # configparser creates option values as list to deal with multiline values
+            self.data[f"{next(self.counter)}:{k}"] = v
+        else:
+            # this is either a SectionProxy object,
+            # or an option value transformed from list form to string(so not a new option)
+            self.data[k] = v
+
+
+class AsteriskConfigParser(configparser.RawConfigParser):
+    def items(self, *args, **kwargs):
+        # Coupled with above CustomConfigParserStorage class as dict_type,
+        # we trick configparser into tracking each duplicate option declarations by storing them under different keys
+        # This reverts the trick in order to expose duplicate options under their real name
+        return [
+            (option.split(":", maxsplit=1)[-1], value)
+            for option, value in super().items(*args, **kwargs)
+        ]
+
+
+def asterisk_parser(food=None) -> AsteriskConfigParser:
+    parser = AsteriskConfigParser(
+        dict_type=CustomConfigParserStorage,
+        strict=False,
+        interpolation=None,
+        empty_lines_in_values=False,
+        inline_comment_prefixes=[";"]
+    )
+    if food:
+        parser.read_file(food)
+    return parser
+
+
+
 def main():
     parsed_args = parse_args()
 
-    config_filename = os.path.expanduser(CONFIG_FILE)
+    config_file = parsed_args.config_file
     try:
-        config = read_config(config_filename)
+        with config_file:
+            config = read_config(config_file)
     except IOError as e:
         if e.errno == errno.ENOENT:
-            print('error: need config file {!r}'.format(config_filename), file=sys.stderr)
+            print('error: need config file {!r}'.format(config_file.name), file=sys.stderr)
             print('Example:\n', file=sys.stderr)
             print('[default]', file=sys.stderr)
             print('host = skaro-dev-1', file=sys.stderr)
@@ -40,15 +87,17 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--profile', default='default',
                         help='profile to use')
+    parser.add_argument('-c', '--config-file', default=CONFIG_FILE,
+                        type=argparse.FileType(mode="r"),
+                        help='config file to use')
     parser.add_argument('command', choices=['make', 'makei'],
                         help='command to execute')
     return parser.parse_args()
 
 
-def read_config(config_filename):
-    config = configparser.RawConfigParser()
-    with open(config_filename) as fobj:
-        config.readfp(fobj)
+
+def read_config(config_file: TextIO):
+    config = asterisk_parser(config_file)
     return config
 
 
@@ -85,15 +134,15 @@ def _build_make_script():
 
 
 def _build_rsync_script(host, directory):
-    return '''
-rsync -v -rlp \
+    return f'''
+    rsync -v -rlp \
     --include '*.c' \
     --include '*.h' \
     --include /device \
     --include /Makefile \
     --exclude '*' \
-    . {host}:{directory}
-'''.format(host=host, directory=directory)
+    . root@{host}:{directory}
+    '''
 
 
 def _exec_local_script(script):
@@ -105,8 +154,7 @@ def _exec_remote_script(script, host):
 
 
 def _exec_command(args, process_input):
-    p = subprocess.Popen(args, stdin=subprocess.PIPE)
-    p.communicate(process_input)
+    p = subprocess.run(args, input=process_input, stdout=subprocess.PIPE, text=True)
     if p.returncode:
         print('command {} returned non-zero status code: {}'.format(args, p.returncode), file=sys.stderr)
 

--- a/buildh
+++ b/buildh
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-import ConfigParser
+import configparser
 import errno
 import os
 import subprocess
@@ -20,11 +20,11 @@ def main():
         config = read_config(config_filename)
     except IOError as e:
         if e.errno == errno.ENOENT:
-            print >>sys.stderr, 'error: need config file {!r}'.format(config_filename)
-            print >>sys.stderr, 'Example:\n'
-            print >>sys.stderr, '[default]'
-            print >>sys.stderr, 'host = skaro-dev-1'
-            print >>sys.stderr, 'directory = wazo-libsccp'
+            print('error: need config file {!r}'.format(config_filename), file=sys.stderr)
+            print('Example:\n', file=sys.stderr)
+            print('[default]', file=sys.stderr)
+            print('host = skaro-dev-1', file=sys.stderr)
+            print('directory = wazo-libsccp', file=sys.stderr)
             raise SystemExit(1)
         else:
             raise
@@ -46,7 +46,7 @@ def parse_args():
 
 
 def read_config(config_filename):
-    config = ConfigParser.RawConfigParser()
+    config = configparser.RawConfigParser()
     with open(config_filename) as fobj:
         config.readfp(fobj)
     return config
@@ -108,7 +108,7 @@ def _exec_command(args, process_input):
     p = subprocess.Popen(args, stdin=subprocess.PIPE)
     p.communicate(process_input)
     if p.returncode:
-        print >>sys.stderr, 'command {} returned non-zero status code: {}'.format(args, p.returncode)
+        print('command {} returned non-zero status code: {}'.format(args, p.returncode), file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/buildh
+++ b/buildh
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 import argparse
 import configparser
@@ -65,9 +64,9 @@ def main():
     try:
         with config_file:
             config = read_config(config_file)
-    except IOError as e:
+    except OSError as e:
         if e.errno == errno.ENOENT:
-            print('error: need config file {!r}'.format(config_file.name), file=sys.stderr)
+            print(f'error: need config file {config_file.name!r}', file=sys.stderr)
             print('Example:\n', file=sys.stderr)
             print('[default]', file=sys.stderr)
             print('host = skaro-dev-1', file=sys.stderr)
@@ -78,7 +77,7 @@ def main():
 
     profile = dict(config.items(parsed_args.profile))
 
-    command_name = 'command_{}'.format(parsed_args.command)
+    command_name = f'command_{parsed_args.command}'
     command_fun = globals()[command_name]
     command_fun(profile)
 
@@ -125,12 +124,12 @@ def command_makei(profile):
 
 
 def _build_cd_script(directory):
-    return "cd '{}'".format(directory)
+    return f"cd '{directory}'"
 
 
 def _build_make_script():
     version = subprocess.check_output(['git', 'describe']).rstrip()
-    return 'make VERSION={}'.format(version)
+    return f'make VERSION={version}'
 
 
 def _build_rsync_script(host, directory):
@@ -156,7 +155,7 @@ def _exec_remote_script(script, host):
 def _exec_command(args, process_input):
     p = subprocess.run(args, input=process_input, stdout=subprocess.PIPE, text=True)
     if p.returncode:
-        print('command {} returned non-zero status code: {}'.format(args, p.returncode), file=sys.stderr)
+        print(f'command {args} returned non-zero status code: {p.returncode}', file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/buildh
+++ b/buildh
@@ -12,7 +12,7 @@ from typing import TextIO
 
 CONFIG_FILE = '~/.wazo-libsccp-buildh-config'
 SHELL = 'sh'
-
+DEFAULT_RSYNC_SSH_CMD = "ssh"
 
 class CustomConfigParserStorage(collections.UserDict):
     """configparser storage class customized for asterisk format parsing"""
@@ -80,16 +80,19 @@ def main():
 
     command_name = f'command_{parsed_args.command}'
     command_fun = globals()[command_name]
-    command_fun(profile)
+    command_fun(profile, rsync_ssh_cmd=parsed_args.rsync_ssh)
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--profile', default='default',
                         help='profile to use')
-    parser.add_argument('-c', '--config-file', default=CONFIG_FILE,
+    parser.add_argument('-c', '--config-file', default=os.path.expanduser(CONFIG_FILE),
                         type=argparse.FileType(mode="r"),
                         help='config file to use')
+    parser.add_argument('-r', '--rsync-ssh', default=DEFAULT_RSYNC_SSH_CMD,
+                        type=str,
+                        help='ssh command to use for rsyncing the build files')
     parser.add_argument('command', choices=['make', 'makei'],
                         help='command to execute')
     return parser.parse_args()
@@ -101,8 +104,8 @@ def read_config(config_file: TextIO):
     return config
 
 
-def command_make(profile: dict):
-    local_script = _build_rsync_script(profile['host'], profile['directory'])
+def command_make(profile: dict[str,str], rsync_ssh_cmd: str=DEFAULT_RSYNC_SSH_CMD):
+    local_script = _build_rsync_script(profile['host'], profile['directory'], ssh_cmd=rsync_ssh_cmd)
     _exec_local_script(local_script)
 
     remote_script = []
@@ -111,8 +114,8 @@ def command_make(profile: dict):
     _exec_remote_script('\n'.join(remote_script), profile['host'])
 
 
-def command_makei(profile: dict):
-    local_script = _build_rsync_script(profile['host'], profile['directory'])
+def command_makei(profile: dict[str, str], rsync_ssh_cmd: str=DEFAULT_RSYNC_SSH_CMD):
+    local_script = _build_rsync_script(profile['host'], profile['directory'], ssh_cmd=rsync_ssh_cmd)
     _exec_local_script(local_script)
 
     remote_script = []
@@ -133,15 +136,15 @@ def _build_make_script() -> str:
     return f'make VERSION={version}'
 
 
-def _build_rsync_script(host: str, directory: str) -> str:
+def _build_rsync_script(host: str, directory: str, ssh_cmd: str=DEFAULT_RSYNC_SSH_CMD) -> str:
     return f'''
-    rsync -v -rlp \
+    rsync -v -e="{ssh_cmd}" -rlp \
     --include '*.c' \
     --include '*.h' \
     --include /device \
     --include /Makefile \
     --exclude '*' \
-    . root@{host}:{directory}
+    . {host}:{directory}
     '''
 
 

--- a/configs/buildh.conf.sample
+++ b/configs/buildh.conf.sample
@@ -1,0 +1,3 @@
+[default]
+host = pcm-dev-primary
+directory = wazo-libsccp

--- a/utils/sccp-confgen
+++ b/utils/sccp-confgen
@@ -23,6 +23,7 @@ cid_num = {{ i }}
 
 '''
 
+
 def main():
     parsed_args = _parse_args()
 
@@ -32,10 +33,12 @@ def main():
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument('-b', '--base', default=0, type=int,
-                        help='base number for device/line')
-    parser.add_argument('n', type=_int_or_random_range,
-                        help='number of devices/lines to create')
+    parser.add_argument(
+        '-b', '--base', default=0, type=int, help='base number for device/line'
+    )
+    parser.add_argument(
+        'n', type=_int_or_random_range, help='number of devices/lines to create'
+    )
     return parser.parse_args()
 
 
@@ -46,6 +49,6 @@ def _int_or_random_range(string: str) -> int:
     else:
         return int(head)
 
+
 if __name__ == "__main__":
     main()
-

--- a/utils/sccp-confgen
+++ b/utils/sccp-confgen
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-# -*- coding: UTF-8 -*-
+#!/usr/bin/env python3
 #
 # Helper script to generate large configuration file for testing purposes.
 

--- a/utils/sccp-confgen
+++ b/utils/sccp-confgen
@@ -43,9 +43,9 @@ def _parse_args():
 def _int_or_random_range(string):
     head, sep, tail = string.partition('-')
     if sep:
-	return random.randint(int(head), int(tail))
+        return random.randint(int(head), int(tail))
     else:
-	return int(head)
+        return int(head)
 
 
 main()

--- a/utils/sccp-confgen
+++ b/utils/sccp-confgen
@@ -30,7 +30,7 @@ def main():
     template.stream(base=parsed_args.base, n=parsed_args.n).dump(sys.stdout)
 
 
-def _parse_args():
+def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--base', default=0, type=int,
                         help='base number for device/line')
@@ -39,12 +39,13 @@ def _parse_args():
     return parser.parse_args()
 
 
-def _int_or_random_range(string):
+def _int_or_random_range(string: str) -> int:
     head, sep, tail = string.partition('-')
     if sep:
         return random.randint(int(head), int(tail))
     else:
         return int(head)
 
+if __name__ == "__main__":
+    main()
 
-main()


### PR DESCRIPTION
* Convert scripts `buildh` and `utils/sccp-confgen` to python 3.
  * for `buildh` this required a custom implementation of the configparser used for the config file(to deal with duplicate option definitions), imported from wazo-confgend
* buildh: added a `-c/--config-file` switch(retaining the same default of `~/~/.wazo-libsccp-buildh-config`)
* Added type annotations
* added section on `buildh` usage to `README.md` based on information by @pc-m  

Tested both scripts successfully.
