### PR TITLE
Add pre commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files
+
+- repo: https://github.com/wazo-platform/wazo-tools
+  rev: master
+  hooks:
+  - id: wazo-copyright-check
+
+- repo: https://github.com/psf/black
+  rev: 22.8.0
+  hooks:
+    - id: black
+      args: [ "--safe", "--skip-string-normalization" ]
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.991
+  hooks:
+  - id: mypy
+    args: ["--ignore-missing-imports", "--check-untyped-defs", "--config-file", "pyproject.toml"]
+    exclude: "bin/"
+    language_version: "3.10"
+    additional_dependencies: ["types-mock", "types-pytz", "types-requests"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ McNamara & Florian Overkamp.
 * https://github.com/wazo-platform/wazo-libsccp
 
 ## buildh
-[buildh](./buildh) is a python script used to compile and install the sccp channel driver on a remote wazo stack. 
+[buildh](./buildh) is a python script used to compile and install the sccp channel driver on a remote wazo stack.
 You need a configuration file with the following content, by default located at `~/.wazo-libsccp-buildh-config`:
 ```
 [default]

--- a/debian/changelog
+++ b/debian/changelog
@@ -55,13 +55,13 @@ xivo-libsccp (13.09~20130507.193207.0a4553b-2) squeeze-xivo-skaro-dev; urgency=l
 xivo-libsccp (13.04~20130222.130010.7dd2e4f-2) squeeze-xivo-skaro-dev; urgency=low
 
   * Non-maintainer upload.
-  * add depends on asterisk11 
+  * add depends on asterisk11
 
  -- Nicolas HICHER <nhicher@avencall.com>  Fri, 22 Feb 2013 12:59:05 -0500
 
 xivo-libsccp (1.2.8~20120510.202303.14a4446-2) squeeze-xivo-skaro-dev; urgency=low
 
-  * add xivo-libsccp-dbg 
+  * add xivo-libsccp-dbg
 
  -- Nicolas HICHER (atarakt) <nhicher@proformatique.com>  Fri, 11 May 2012 11:15:23 -0400
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"
+
+[project]
+name = "wazo-libsccp"
+description = "asterisk module implementation to support sccp protocol"
+readme = "README.md"
+requires-python = ">=3.7"
+license = { file = "LICENSE" }
+version = "0.2"
+
+[tools.setuptools]
+
+[tool.black]
+skip-string-normalization = true
+
+[tool.mypy]
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+follow_imports = "skip"
+ignore_missing_imports = true
+check_untyped_defs = true
+explicit_package_bases = true
+scripts_are_modules = true
+
+[tool.flake8]
+exclude = ".tox,.eggs,.venv"
+show-source = true
+# E501: line too long (80 chars)
+# W503: line break before binary operator
+ignore = "E501, W503"
+max-line-length = 99
+application-import-names = "wazo_confgend"


### PR DESCRIPTION
Depends-On: WAZO-2818-python-3

Adds a pre-commit config to support pre-commit tool and git-hooks.
For this a pyproject.toml is also added as a common configuration file for linters, formatters, etc.