### PR TITLE
mypy: use default import following policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
     - id: check-yaml
     - id: check-added-large-files
 
-- repo: https://github.com/wazo-platform/wazo-tools
-  rev: master
+- repo: https://github.com/wazo-platform/wazo-git-hooks
+  rev: 1.1.1
   hooks:
   - id: wazo-copyright-check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 no_implicit_optional = true
-follow_imports = "skip"
 ignore_missing_imports = true
 check_untyped_defs = true
 explicit_package_bases = true


### PR DESCRIPTION
Why:

* This option makes pre-commit miss some typing errors