### PR TITLE
pre-commit: bump mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     - id: black
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.991
+  rev: v1.19.1
   hooks:
   - id: mypy
     language_version: "3.11"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Build/Tooling**: Update static type checker version in pre-commit.
> 
> - Bumps `mypy` hook in `.pre-commit-config.yaml` from `v0.991` to `v1.19.1` (Python `3.11` remains configured)
> - No application code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1329c63e896ee19afd68f60e3f41fc430d961696. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->